### PR TITLE
Fixed erreur dans une commande

### DIFF
--- a/odeva.md
+++ b/odeva.md
@@ -481,7 +481,7 @@ git push origin master
 cd ../testGitLocal
 touch y.txt && git add y.txt
 git commit -am "Add y"
-git pull --rebase
+git pull --rebase origin master
 git push origin master
 ```
 


### PR DESCRIPTION
Il manquait deux arguments dans la commande `git pull --rebase origin master`.